### PR TITLE
The argument name of block_pour_docx() is `file` instead of `docx_file`

### DIFF
--- a/vignettes/officer.Rmd
+++ b/vignettes/officer.Rmd
@@ -68,7 +68,7 @@ for multi-columns sections and for tables of contents.
 
 And the following will pour the content of an external docx file into the produced document:
 
-`r taghl("<!---BLOCK_POUR_DOCX{docx_file: 'path/to/docx'}--->")`</pre>
+`r taghl("<!---BLOCK_POUR_DOCX{file: 'path/to/docx'}--->")`</pre>
 
 > The parameters are defined in a yaml string. Each item in the list is a list of 
 key/value pairs defined with `key: value` form (the colon must be followed by a space).


### PR DESCRIPTION
Thanks for the awesome package!

BTW, in the next section, I don't think functions `block_section_continuous` and `block_section_landscape` still exist in **officer**. I'll leave it to you to update that.