### PR TITLE
Alternative text can be added to image in Word document with a chunk option.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,10 +25,11 @@ Encoding: UTF-8
 LazyData: true
 Imports: knitr, 
  rmarkdown, 
- officer (>= 0.3.17), 
+ officer (>= 0.3.16), 
  xml2, rlang, uuid,
  grDevices, yaml, utils, memoise, 
  rvg (>= 0.2.2)
+Remotes: davidgohel/officer
 Suggests: ggplot2, flextable, bookdown (>= 0.13)
 URL: https://ardata-fr.github.io/officeverse/, https://davidgohel.github.io/officedown
 BugReports: https://github.com/davidgohel/officedown/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Encoding: UTF-8
 LazyData: true
 Imports: knitr, 
  rmarkdown, 
- officer (>= 0.3.15), 
+ officer (>= 0.3.17), 
  xml2, rlang, uuid,
  grDevices, yaml, utils, memoise, 
  rvg (>= 0.2.2)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Authors@R: c(
     person(given = "Institut für Qualitätssicherung und Transparenz im Gesundheitswesen", role = c("fnd")),
     person("Noam", "Ross", role = c("aut"), email = 'noam.ross@gmail.com', 
     comment = "rmarkdown implementation for rvg"),
-    person(given = "ArData", role = "cph")
+    person(given = "ArData", role = "cph"),
+    person("Martin", "Camitz", role = c("ctb"), email = 'martin.camitz@gmail.com') 
     )
 Description: Allows production of 'Microsoft' corporate documents from 'R Markdown' by 
  reusing formatting defined in 'Microsoft Word' documents. You can reuse table styles, 

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -7,6 +7,7 @@
 plot_word_fig_caption <- function(x, options) {
 
   if(!is.character(options$fig.cap)) options$fig.cap <- NULL
+  if(!is.character(options$fig.alt)) options$fig.alt <- NULL
   if(is.null(options$fig.id))
     fig.id <- options$label
   else fig.id <- options$fig.id
@@ -39,8 +40,15 @@ plot_word_fig_caption <- function(x, options) {
     fig.style_id <- style_id("Normal", type = "paragraph", si)
 
   }
+
+  ooxml <- to_wml(img)
+  if(!is.null(options$fig.alt)) {
+    ooxml <- gsub('(<wp:docPr.*?)/>','\\1 descr="%s"/>', ooxml)
+    ooxml <- sprintf(ooxml, options$fig.alt)
+  }
+
   ooxml <- paste0("<w:p><w:pPr><w:jc w:val=\"%s\"/><w:pStyle w:val=\"%s\"/></w:pPr>",
-         to_wml(img),
+         ooxml,
          "</w:p>"
          )
   ooxml <- sprintf(ooxml, opts_current$get("fig.align"), fig.style_id)

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -7,6 +7,7 @@
 plot_word_fig_caption <- function(x, options) {
 
   if(!is.character(options$fig.cap)) options$fig.cap <- NULL
+  if(!is.character(options$fig.alt)) options$fig.alt <- NULL
   if(is.null(options$fig.id))
     fig.id <- options$label
   else fig.id <- options$fig.id
@@ -25,7 +26,7 @@ plot_word_fig_caption <- function(x, options) {
   fig.height <- opts_current$get("fig.height")
   if(is.null(fig.height)) fig.height <- 5
 
-  img <- external_img(src = x[1], width = fig.width, height = fig.height)
+  img <- external_img(src = x[1], width = fig.width, height = fig.height, alt = options$fig.alt)
 
   doc <- get_reference_rdocx()
   si <- styles_info(doc)

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -7,7 +7,6 @@
 plot_word_fig_caption <- function(x, options) {
 
   if(!is.character(options$fig.cap)) options$fig.cap <- NULL
-  if(!is.character(options$fig.alt)) options$fig.alt <- NULL
   if(is.null(options$fig.id))
     fig.id <- options$label
   else fig.id <- options$fig.id
@@ -40,15 +39,8 @@ plot_word_fig_caption <- function(x, options) {
     fig.style_id <- style_id("Normal", type = "paragraph", si)
 
   }
-
-  ooxml <- to_wml(img)
-  if(!is.null(options$fig.alt)) {
-    ooxml <- gsub('(<wp:docPr.*?)/>','\\1 descr="%s"/>', ooxml)
-    ooxml <- sprintf(ooxml, options$fig.alt)
-  }
-
   ooxml <- paste0("<w:p><w:pPr><w:jc w:val=\"%s\"/><w:pStyle w:val=\"%s\"/></w:pPr>",
-         ooxml,
+         to_wml(img),
          "</w:p>"
          )
   ooxml <- sprintf(ooxml, opts_current$get("fig.align"), fig.style_id)

--- a/inst/examples/minimal_word.Rmd
+++ b/inst/examples/minimal_word.Rmd
@@ -51,7 +51,7 @@ see figure \@ref(fig:boxplot) and table \@ref(tab:mtcars)!
 
 ### A boxplot
 
-```{r fig.cap="A boxplot", fig.id = "boxplot"}
+```{r fig.cap="A boxplot", fig.id = "boxplot", fig.alt="Alternative text for screen readers"}
 boxplot(1:8)
 ```
 


### PR DESCRIPTION
This change enables the addition of alternate texts to images in word with an ad hoc chuck option: `fig.alt`.

I issue this pull request in part to highlight the need for the alt text functionality but mainly the general extensibility of the _officeverse_.

### Background
I work for the Public Health Agency in Sweden in the modelling unit. We are very pleased with _officedown_ and the entire _officeverse_ chain. Our initial experiments into officedown are very promising and we hope to develop a routine to automate the publishing of statistics and modelling result to our public web page. This activity has naturally increased sharply in frequency over the past months. The model will be disseminated throughout the agency.

By law we are required in Sweden to make all publications [accessible](https://en.wikipedia.org/wiki/Accessibility). The alternative text is essential for this. Reader software used by persons with visual impairments can be provided a detailed description of the image.

Without making any changes in any dependencies, we have eliminated every manual task associated with the publishing, except in this instance. After generation of the word file we would need edit the file in _Word_ and add the text for each of our plots. Quite cumbersome.

It turns out that the XML for the alt-text is extremely simple. It's just an attribute. Adding the alt-text manually in Word is comparatively complicated.

### General remarks
I haven't done a huge amount of research into the source code, so I might be off in this. In any case I certainly invite further discussion.

I regard the proposed change as a short lived hack. We are pleased with its functionality for the time being but the implementation is not pretty, as is apparent to everyone. For one thing it is hidden within a function clearly named and commented as having a specific purpose. Although that is addressable, this hack, unless it is merged, is likely to conflict with future updates and maintaining it will prove hard. 

A better option for this and I assume many other similar issues other developers have encountered, would be support extending officedown, for example through the use of hooks. As I understand it officedown works by hooking in to rmarkdown in various ways and in doing so overwrites some of the output hooks of _knitr_ that may have been set, by necessity, of course. 

To be able to do something like the following would be marvelous.

    knitr::knit_hooks$set(NAME = my_funtion_to_add_alt_text(....

In a larger scope one would desire that officedown isolate itself from the xml undertakings of officer and pandoc entirely, but as I understand it this is not possible without a rather hefty revision of the pipeline. I first sought a way for my proposed functionality to be implemented in officer and hoped any additional chunk options would be passed down. One would need the ability to pass down metadata along with the image in a format agnostic way, but as I understand it, only the file path is.