### PR TITLE
Support for reverse order of caption and figure

### DIFF
--- a/R/hooks.R
+++ b/R/hooks.R
@@ -10,7 +10,8 @@ plot_word_fig_caption <- function(x, options) {
   if(is.null(options$fig.id))
     fig.id <- options$label
   else fig.id <- options$fig.id
-
+  if(!is.logical(options$fig.cap.below_fig)) options$fig.cap.below_fig <- TRUE
+  
   bc <- block_caption(label =  options$fig.cap, style = options$fig.cap.style,
                       autonum = run_autonum(
                         seq_id = gsub(":$", "", options$fig.lp),
@@ -46,5 +47,7 @@ plot_word_fig_caption <- function(x, options) {
   ooxml <- sprintf(ooxml, opts_current$get("fig.align"), fig.style_id)
   img_wml <- paste("```{=openxml}", ooxml, "```", sep = "\n")
 
-  paste("", img_wml, cap_str, sep = "\n\n")
+  ifelse(options$fig.cap.below_fig,
+         paste("", img_wml, cap_str, sep = "\n\n"),
+         paste("", cap_str, img_wml, sep = "\n\n"))
 }

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -10,7 +10,7 @@ plot_word_fig_caption <- function(x, options) {
   if(is.null(options$fig.id))
     fig.id <- options$label
   else fig.id <- options$fig.id
-  if(!is.logical(options$fig.cap.below_fig)) options$fig.cap.below_fig <- TRUE
+  if(!is.logical(options$fig.topcaption)) options$fig.topcaption <- FALSE
   
   bc <- block_caption(label =  options$fig.cap, style = options$fig.cap.style,
                       autonum = run_autonum(
@@ -47,7 +47,8 @@ plot_word_fig_caption <- function(x, options) {
   ooxml <- sprintf(ooxml, opts_current$get("fig.align"), fig.style_id)
   img_wml <- paste("```{=openxml}", ooxml, "```", sep = "\n")
 
-  ifelse(options$fig.cap.below_fig,
-         paste("", img_wml, cap_str, sep = "\n\n"),
-         paste("", cap_str, img_wml, sep = "\n\n"))
+  if (options$fig.topcaption)
+    paste("", cap_str, img_wml, sep = "\n\n")
+  else
+    paste("", img_wml, cap_str, sep = "\n\n")
 }

--- a/R/rdocx_document.R
+++ b/R/rdocx_document.R
@@ -60,6 +60,7 @@ tables_default_values <- list(
 plots_default_values <- list(
   style = "Figure",
   align = "center",
+  topcaption = FALSE,
   caption = list(
     style = "Image Caption",
     pre = "Figure ", sep = ": "
@@ -144,6 +145,7 @@ get_reference_rdocx <- memoise(get_docx_uncached)
 #' * `style`: the Word stylename to use for plots.
 #' * `align`: alignment of figures in the output document (possible values are 'left',
 #' 'right' and 'center').
+#' * `topcaption`: caption will appear before (on top of) the figure,
 #' * `caption`; caption options, i.e.:
 #'   * `style`: Word stylename to use for figure captions.
 #'   * `pre`: prefix for numbering chunk (default to "Figure ").
@@ -152,7 +154,7 @@ get_reference_rdocx <- memoise(get_docx_uncached)
 #' Default value is (in R format):
 #' ```
 #' list(
-#'   style = "Normal", align = "center",
+#'   style = "Normal", align = "center", topcaption = FALSE,
 #'   caption = list(
 #'     style = "Image Caption",
 #'     pre = "Figure ",
@@ -165,6 +167,7 @@ get_reference_rdocx <- memoise(get_docx_uncached)
 #' ```
 #' style: Normal
 #' align: center
+#' topcaption: false
 #' caption:
 #'   style: Image Caption
 #'   pre: 'Figure '
@@ -350,7 +353,8 @@ rdocx_document <- function(base_format = "rmarkdown::word_document",
          fig.cap.sep = plots$caption$sep,
          fig.align = plots$align,
          fig.style = plots$style,
-         fig.lp = "fig:"
+         fig.lp = "fig:",
+         fig.topcaption = plots$topcaption
          )
     )
   if(is.null(output_formats$knitr$knit_hooks)){


### PR DESCRIPTION
Using chunk option fig.cap.below_fig = FALSE (default true), caption appears bove figure in output.