### PR TITLE
adds the md2-switch for number_section

### DIFF
--- a/R/rdocx_document.R
+++ b/R/rdocx_document.R
@@ -232,6 +232,7 @@ get_reference_rdocx <- memoise(get_docx_uncached)
 #' document. `list("Normal" = c("Author", "Date"))` will result in a document where
 #' all paragraphs styled with stylename "Date" and "Author" will be then styled with
 #' stylename "Normal".
+#' @param md2 if TRUE sets number_section to true
 #' @param reference_num if TRUE, text for references to sections will be
 #' the section number (e.g. '3.2'). If FALSE, text for references to sections
 #' will be the text (e.g. 'section title').
@@ -310,6 +311,7 @@ get_reference_rdocx <- memoise(get_docx_uncached)
 #'       ul.style: null
 #'     mapstyles:
 #'       Normal: ['First Paragraph', 'Author', 'Date']
+#'     md2: false
 #'     page_size:
 #'       width: 8.3
 #'       height: 11.7
@@ -375,19 +377,28 @@ get_reference_rdocx <- memoise(get_docx_uncached)
 rdocx_document <- function(base_format = "rmarkdown::word_document",
                            tables = list(), plots = list(), lists = list(),
                            mapstyles = list(), page_size = list(), page_margins = list(),
-                           reference_num = TRUE, ...) {
+                           md2 = FALSE, reference_num = TRUE, ...) {
 
   args <- list(...)
-  if(is.null(args$reference_docx)){
+  if(is.null(args$reference_docx)) {
     args$reference_docx <- system.file(
       package = "officedown", "examples",
       "bookdown", "template.docx"
     )
   }
-  if(!is.null(args$number_sections) && isTRUE(args$number_sections)){
-    args$number_sections <- FALSE
-  }
-
+  
+ 
+ 
+ # hint: original change modified to allow for the md2-switch
+ if(!is.null(args$number_sections) && isTRUE(args$number_sections)) {
+   if (isTRUE(md2)) {
+      args$number_sections <- TRUE
+   } else {
+      args$number_sections <- FALSE
+   }
+  
+ }
+  
   args$reference_docx <- absolute_path(args$reference_docx)
 
   base_format_fun <- get_fun(base_format)


### PR DESCRIPTION
By default the `number_section` argument is set to false if used with `bookdown::markdown_document2`.
In case the auto-numbering feature of bookdown in this combination of bookdown and officedown is needed the new md2-switch is added. Its default value is `FALSE`.
I found no native way to check, if `number_section` is set to `FALSE` manually or by code. Hence a new parameter seems to be a straightforward solution.